### PR TITLE
Fixes the image path for header image.

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ function processDoc(opts) {
   if (options.image) {
     if (!/^((https?:)?\/\/|\.\.\/)/.test(options.image)) {
       fstreams.push(streamFile(options.image, 'img', fakeDest));
-      options.image = 'img/' + options.image;
+      options.image = 'img/' + path.basename(options.image);
     }
   }
 


### PR DESCRIPTION
Using path.basename to extract the file name of the image.
Without doing this, the image src will be /img/original/path/to/image,
which is not how it gets copied into the docs/img folder.
