### PR TITLE
Prevent crashing gulp.watch when @name is not set.

### DIFF
--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -367,7 +367,7 @@ Doc.prototype = {
       }
     });
     flush();
-    this.shortName = this.name ? this.name.split(/[\.:#]/).pop().trim(): '';
+    this.shortName = this.name ? this.name.split(/[\.:#]/).pop().trim() : '';
     this.id = this.id || // if we have an id just use it
       (this.ngdoc === 'error' ? this.name : '') ||
       (((this.file||'').match(/.*(\/|\\)([^(\/|\\)]*)\.ngdoc/)||{})[2]) || // try to extract it from file name


### PR DESCRIPTION
When watching a file and saving it without @name being set, `gulp.watch` would crash because of a split operation on an undefined string. This fixes that issue.
