### PR TITLE
fix(parser): @eventType parsing does not match the documented format

### DIFF
--- a/spec/ngdocSpec.js
+++ b/spec/ngdocSpec.js
@@ -92,6 +92,14 @@ describe('ngdoc', function() {
         });
       });
 
+      it('should parse eventType', function() {
+        var doc = new Doc('@name a\n@eventType broadcast');
+        doc.parse();
+        expect(doc.returns).toEqual({
+          type: 'broadcast'
+        });
+      });
+
       it('should parse filename', function() {
         var doc = new Doc('@name friendly name', 'docs/a.b.ngdoc', 1);
         doc.parse(0);

--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -434,9 +434,8 @@ Doc.prototype = {
           });
           self.properties.push(property);
         } else if(atName == 'eventType') {
-          match = text.match(/^([^\s]*)\s+on\s+([\S\s]*)/);
+          match = text.match(/(broadcast|emit)/);
           self.type = match[1];
-          self.target = match[2];
         } else {
           self[atName] = text;
         }


### PR DESCRIPTION
Resolving issue #18 to use the ngdocs standard as documented at https://github.com/angular/angular.js/wiki/Writing-AngularJS-Documentation for @eventType.