### PR TITLE
Saving folder structure when copying files into 'js' folder.

### DIFF
--- a/index.js
+++ b/index.js
@@ -268,12 +268,12 @@ function processDoc(opts) {
 
   var scriptNames = [];
   options.scripts = _.map(options.scripts, function (file) {
-    var fileName = path.normalize(file).split('/').pop();
+    var fileName = path.normalize(file);
     scriptNames.push(fileName);
     if (/^((https?:)?\/\/)/.test(file)) {
       return file;
     } else {
-      fstreams.push(streamFile(file, 'js', fakeDest));
+      fstreams.push(streamFile(file, path.join('js', path.dirname(fileName)), fakeDest));
       return path.join('js', fileName);
     }
   });
@@ -292,11 +292,12 @@ function processDoc(opts) {
   });
 
   options.styles = _.map(options.styles, function(file) {
+      var fileName = path.normalize(file);
     if (/^((https?:)?\/\/)/.test(file)) {
       return file;
     } else {
-      fstreams.push(streamFile(file, 'css', fakeDest));
-      return 'css/' + path.normalize(file).split('/').pop();
+      fstreams.push(streamFile(file, path.join('css', path.dirname(fileName)), fakeDest));
+      return path.join('css', fileName);
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ function processDoc(opts) {
     setup.editExample = options.editExample;
     setup.startPage = options.startPage;
     setup.discussions = options.discussions;
-    setup.scripts = _.map(options.scripts, function(url) { return path.basename(url); });
+    setup.scripts = options.scripts;
     docsStream.push(new File({
       base: fakeDest,
       cwd: fakeDest,

--- a/src/templates/js/docs.js
+++ b/src/templates/js/docs.js
@@ -112,17 +112,20 @@ docsApp.directive.sourceEdit = function(getEmbeddedTemplate) {
 
 docsApp.serviceFactory.loadedUrls = function($document) {
   var urls = {};
+    var tmp = document.createElement ('a');
 
   angular.forEach($document.find('script'), function(script) {
+    tmp.href = script.src;
     var match = script.src.match(/^.*\/([^\/]*\.js)$/);
     if (match) {
-      urls[match[1].replace(/(\-\d.*)?(\.min)?\.js$/, '.js')] = match[0];
+      urls[tmp.pathname] = match[0];
     }
   });
 
   urls.base = [];
   angular.forEach(NG_DOCS.scripts, function(script) {
-    var match = urls[script.replace(/(\-\d.*)?(\.min)?\.js$/, '.js')];
+    tmp.href = script;
+    var match = urls[tmp.pathname];
     if (match) {
       urls.base.push(match);
     }


### PR DESCRIPTION
These changes saves folder structure when copying files.
Without these changes files with the same names will be overwritten.