### PR TITLE
Fix #57 :: minor tweaks to URL regex

### DIFF
--- a/src/templates/index.tmpl
+++ b/src/templates/index.tmpl
@@ -18,7 +18,7 @@
     // before the base attribute is added, causing 404 and terribly slow loading of the docs app.
     (function() {
       var indexFile = (location.pathname.match(/\/(index[^\.]*\.html)/) || ['', ''])[1],
-          rUrl = /(#!\/|<%= sections %>|index[^\.]*\.html).*$/,
+          rUrl = /(#!\/|<%= sections %>|index[^\./]*\.html).*$/,
           origin = location.origin || (window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '')),
           baseUrl = origin + location.href.substr(origin.length).replace(rUrl, indexFile),
           headEl = document.getElementsByTagName('head')[0],


### PR DESCRIPTION
The URL regex used to modify `location.href` to generate the
baseUrl for JS and CSS assets was stripping off the project
name if it contained 'index'.

Modified `index[^\.]*` to `index[^\./]*` so it doesn't match
in the middle of the path.

See [this regexr to view the problem](http://regexr.com/3bjqc)