### PR TITLE
Deleting .bowerrc since bower is no more used

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,0 @@
-{
-	"directory": "bower_components"
-}


### PR DESCRIPTION
Small PR for removing bower configuration file, as bower dependencies have been removed in the previous release **([v0.2.13](https://github.com/nikhilmodak/gulp-ngdocs/releases/tag/v0.2.13))**.