### PR TITLE
Do no bundle angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ gulp.task('ngdocs', [], function () {
 });
 ```
 
-To use a different angularjs version pass `angular` and `angular-animate` files in scripts.
+Please specify you own version of angular and angular-animate. They will not be included by default.
 
 ```js
 gulp.task('ngdocs', [], function () {
@@ -53,20 +53,6 @@ gulp.task('ngdocs', [], function () {
       'bower_components/angular-animate/angular-animate.min.js.map'
     ]
   }
-
-  /*
-  If you choose to use the remote links pass in the .min.js links for angular and angular-animate
-
-  var options = {
-    scripts: [
-      'http://ajax.googleapis.com/ajax/libs/angularjs/<version>/angular.min.js',
-      'http://ajax.googleapis.com/ajax/libs/angularjs/<version>/angular-animate.min.js'
-    ]
-  }
-  */
-  return gulp.src('path/to/src/*.js')
-    .pipe(gulpDocs.process(options))
-    .pipe(gulp.dest('./docs'));
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -106,14 +106,6 @@ function processDoc(opts) {
 
   //Default root paths for scripts
   var scriptPaths = {
-    angular : [
-      'angular/angular.min.js',
-      'angular/angular.min.js.map'
-    ],
-    angularAnimate: [
-      'angular-animate/angular-animate.min.js',
-      'angular-animate/angular-animate.min.js.map'
-    ],
     marked: [
       'marked/lib/marked.js'
     ]

--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
     "string_decoder": "0.10.31",
     "through2": "0.6.1",
     "canonical-path": "0.0.2",
-    "angular": "~1.3.1",
-    "angular-animate": "~1.3.1",
     "marked": "0.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently, gulp-ngdocs tries to load some version of angular and to use your own you must override four different files (angular.min.js, angular.min.js.map, angular-animate.min.js, angular-animate.min.js.map). Besides the fact that it's annoying, it also crashes silently for me when I try to include the min files. I can't think of why anyone would want to use a version the ships with ng-docs. If you're using gulp-ngdocs, don't you already have your own angular lying around?