### PR TITLE
prevent errors when loading the page

### DIFF
--- a/src/templates/js/angular-bootstrap-prettify.js
+++ b/src/templates/js/angular-bootstrap-prettify.js
@@ -254,8 +254,13 @@ directive.ngEmbedApp = ['$templateCache', '$browser', '$rootScope', '$location',
       });
 
       element.bind('$destroy', function() {
-        deregisterEmbedRootScope();
-        embedRootScope.$destroy();
+        if(deregisterEmbedRootScope){
+          deregisterEmbedRootScope()
+        }
+
+        if(embedRootScope){
+          embedRootScope.$destroy();
+        }
       });
 
       element.data('$injector', null);


### PR DESCRIPTION
angular-bootstrap-prettify.js fails when the scope is not ready
