### PR TITLE
Bug fix? I think @function always leads to "new " in usage

### DIFF
--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -461,6 +461,8 @@ Doc.prototype = {
         } else if(atName == 'eventType') {
           match = text.match(/(broadcast|emit)/);
           self.type = match[1];
+        } else if(atName == 'constructor') {
+          self.constructor = true;
         } else {
           self[atName] = text;
         }
@@ -656,6 +658,9 @@ Doc.prototype = {
 
     dom.h('Usage', function() {
       dom.code(function() {
+        if (self.constructor) {
+          dom.text('new ');
+        }
         dom.text(name.split(':').pop());
         dom.text('(');
         self.parameters(dom, ', ');

--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -462,7 +462,7 @@ Doc.prototype = {
           match = text.match(/(broadcast|emit)/);
           self.type = match[1];
         } else if(atName == 'constructor') {
-          self.constructor = true;
+          self.functionIsConstructor = true;
         } else {
           self[atName] = text;
         }
@@ -658,7 +658,7 @@ Doc.prototype = {
 
     dom.h('Usage', function() {
       dom.code(function() {
-        if (self.constructor) {
+        if (self.functionIsConstructor) {
           dom.text('new ');
         }
         dom.text(name.split(':').pop());


### PR DESCRIPTION
I took these lines from grunt-ngdocs, but I imagine it is broken there... Doc.constructor test always returned true, likely secondary to constructor property on prototype and truthy versus truth.