### PR TITLE
ul.methods css class has an unappealing offset

### DIFF
--- a/src/templates/css/docs.css
+++ b/src/templates/css/docs.css
@@ -207,6 +207,10 @@ ul.events > li {
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
 }
 
+ul.methods {
+  margin-left: 0;
+}
+
 .member.method > h2,
 .member.property > h2,
 .member.event > h2 {


### PR DESCRIPTION
ul.methods css had an offset that was not aesthetically pleasing when viewing the methods table. This offset was due to bootstrap overriding the ul.methods class so I added a margin-left: 0; to counter it.

 `ul.methods { margin-left: 0; } `