### PR TITLE
Fix `rUrl` regex

### DIFF
--- a/src/templates/index.tmpl
+++ b/src/templates/index.tmpl
@@ -18,7 +18,7 @@
     // before the base attribute is added, causing 404 and terribly slow loading of the docs app.
     (function() {
       var indexFile = (location.pathname.match(/\/(index[^\.]*\.html)/) || ['', ''])[1],
-          rUrl = /(#!\/|<%= sections %>|index[^\./]*\.html).*$/,
+          rUrl = /((#!\/|<%= sections %>|index)[^\./]*\.html).*$/,
           origin = location.origin || (window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '')),
           baseUrl = origin + location.href.substr(origin.length).replace(rUrl, indexFile),
           headEl = document.getElementsByTagName('head')[0],


### PR DESCRIPTION
Similar to #57, the regex for rUrl strips out the `<%= sections %> strings from the repo name.